### PR TITLE
Changed oauth to use personal token authentication method.

### DIFF
--- a/IP_admin.php
+++ b/IP_admin.php
@@ -42,13 +42,14 @@ class UPIP_admin {
       <?php settings_fields('upip_options'); ?>
       <?php $options = get_option('upip_options'); ?>
       <table class="form-table">
-        <tr valign="top"><th scope="row">Github Username</th>
-          <td><input type="text" name="upip_options[u]" value="<?php echo $options['u']; ?>" /></td>
+        <tr valign="top"><th scope="row">Github Access Token:</th>
+          <td><input type="text" name="upip_options[oauth_key]" value="<?php echo $options['oauth_key']; ?>" />
+          <?php if( !$options['oauth_key'] ){ ?>
+           <p><a target="_blank" href="https://github.com/settings/tokens/new">Generate an access token</a> and paste it here. We recommend setting up an IssuePress-specific Github account (with proper access to your repositories) for most installations.</p>
+           <?php } ?>
+          </td>
         </tr>
-        <tr valign="top"><th scope="row">Github Password</th>
-          <td><input type="password" name="upip_options[p]" value="<?php echo $options['p']; ?>" /></td>
-        </tr>
-        <tr valign="top"><th scope="row">Support Landing Page</th>
+        <tr valign="top"><th scope="row">Support Landing Page:</th>
           <td>
             <select id="upip_options" name="upip_options[landing]">
             <option value="">Select Page</option>
@@ -114,10 +115,11 @@ class UPIP_admin {
 
           <td>
         </tr>
-  <?php if(!empty($options['u']) && !empty($options['p'])) {
+  <?php if( !empty($options['oauth_key']) ) {
 
     $client = new Github\Client();
-    $client->authenticate($options['u'], $options['p'], Github\Client::AUTH_HTTP_PASSWORD);
+    $client->authenticate($options['oauth_key'], null, Github\Client::AUTH_HTTP_TOKEN);
+
     $gh_repos = $client->api('current_user')->repositories(array('per_page' => 100));
 
     $current_repos = array();

--- a/IssuePress.php
+++ b/IssuePress.php
@@ -24,11 +24,11 @@ if(!defined('IP_ITEM_NAME'))
 define('IP_MAIN_PLUGIN_FILE', __FILE__ );
 
 require_once 'vendor/autoload.php';
-require_once 'IP_admin.php';
-require_once 'IP_license_admin.php';
 require_once 'IP_api.php';
 require_once 'IP_helpers.php';
 require_once 'widgets/load.php';
+require_once 'IP_admin.php';
+require_once 'IP_license_admin.php';
 
 if( !class_exists( 'IP_Plugin_Updater' ) ) {
   // load our custom updater


### PR DESCRIPTION
Rather than storing a username and password or authorizing IssuePress via an official "application" I decided to simply offer users a way to generate and store a "personal access token" which is basically the same as sending them off to generate a token via the application method. This is likely our best option at this point, as we don't want to store username/password combos in the database and can't really authenticate via a third-party "app" because we'd have to route users through our server in order to authenticate.
