### PR TITLE
Add cache clear functionality. Add repo cache clear to clear all related...

### DIFF
--- a/IP_api.php
+++ b/IP_api.php
@@ -656,6 +656,23 @@ Sent via [IssuePress](http://issuepress.co)
     return $data;
   }
 
+  /**
+   * IP cache clear
+   *
+   * Utility function wrapping the delete_transient(),
+   * first checks if IP cache is enabled, proceeds if so.
+   *
+   * @param $key STRING
+   * @return TRUE if successful, FALSE otherwise 
+   */
+  private function ip_cache_clear($key='') {
+    if(!$this->cacheIsOn || $key == '')
+      return false;
+
+    $clear = delete_transient('ip-'.$key); // Note the prepending 'ip-'
+    return $clear;
+  }
+
   /*** END IP Cache Functions ***/
 
 
@@ -699,5 +716,35 @@ Sent via [IssuePress](http://issuepress.co)
     return $repoCache;
 
   }
+
+
+  /**
+   * IP Repo Cache Clear
+   *
+   * Utility function to clear all related transients for a repo
+   *
+   * @param $key STRING
+   * @return void
+   */
+  public function ip_clear_repo_cache($repo=''){
+
+    $cacheKeys = array(
+      'repo',
+      'issues',
+      'activity',
+      'comments',
+//      'releases', Releases currently disabled
+    );
+
+    foreach($cacheKeys as $key){
+
+      $this->ip_cache_clear($repo . '-' . $key);
+
+    }
+
+    return;
+
+  }
+
 
 }

--- a/IssuePress.php
+++ b/IssuePress.php
@@ -94,6 +94,7 @@ class UP_IssuePress {
     add_action('init', array($this, 'register_IP_scripts'), 0);
     add_action('ip_head', array($this, 'print_IP_scripts'), 20);
     add_action('update_option_issuepress_options', array($this, 'create_IP_labels'), 5, 2);
+    add_action('update_option_issuepress_options', array($this, 'clear_IP_cache'), 5, 2);
     add_action('admin_print_styles', array($this, 'resize_icon'), 20);
     add_action('widgets_init', array($this, 'register_IP_sidebars'), 0);
     add_action('admin_init', array($this, 'theme_updater'),0);
@@ -335,6 +336,27 @@ class UP_IssuePress {
     return;
 
   }
+
+
+  /**
+  * Clear IP cache  
+  *
+  * @return void
+  */
+  public function clear_IP_cache($old, $new) {
+
+    if(empty($old['upip_gh_repos'])){ 
+      return;
+    }
+
+    foreach($old['upip_gh_repos'] as $r){ 
+      $this->ip_api->ip_clear_repo_cache($r);
+    }
+
+    return;
+
+  }
+
 
 
   /**


### PR DESCRIPTION
... transients for a repo. Clear old repos cache when list of repos updated. #85 - this shouldn't be totally necessary as we build front-end content based on the values in the repo options, and if transients exist for a repo we output them, if not, we send empty json. Probably a case of "better safe than sorry"...
